### PR TITLE
Updates for Ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "http://rubygems.org"
 
+  gem "jeweler"
+  
 group :test do
   gem "rake"
   gem "minitest", :require => "minitest/unit"

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
+require 'jeweler'
 
 task :default => :test
 


### PR DESCRIPTION
If Jeweler is not in the Gemfile, Rake won't use it for packaging the Gem, it'll fail to find it

Rake Rdoc task has changed to rdoc/task

Pulled the require 'Jeweler' up to keep things clean and consistent
