### PR TITLE
Keep core extensions in separate file(s)

### DIFF
--- a/lib/bencode/core_ext/string.rb
+++ b/lib/bencode/core_ext/string.rb
@@ -2,13 +2,23 @@
 class String
   #
   # Bencodes the String object. Bencoded strings are represented
-  # as <code>x</code>:<code>y</code>, where +y+ is the string and +x+ 
+  # as <code>x</code>:<code>y</code>, where +y+ is the string and +x+
   # is the length of the string.
-  #   
+  #
   #   "foo".bencode   #=> "3:foo"
   #   "".bencode      #=> "0:"
   #
   def bencode
     "#{length}:#{self}"
+  end
+
+  #
+  # Bdecodes the String object and returns the data serialized
+  # through bencoding.
+  #
+  #   "li1ei2ei3ee".bdecode   #=> [1, 2, 3]
+  #
+  def bdecode
+    BEncode.load(self)
   end
 end

--- a/lib/bencode/decode.rb
+++ b/lib/bencode/decode.rb
@@ -22,7 +22,7 @@ module BEncode
     scanner = BEncode::Parser.new(str)
     obj = scanner.parse!
     raise BEncode::DecodeError unless (opts[:ignore_trailing_junk] || scanner.eos?)
-    return obj
+    obj
   end
 
   # Decodes the file located at +path+.
@@ -32,17 +32,5 @@ module BEncode
   # @return (see .load)
   def self.load_file(path, opts = {})
     load(File.open(path, 'rb').read, opts)
-  end
-end
-
-class String
-  #
-  # Bdecodes the String object and returns the data serialized
-  # through bencoding.
-  #
-  #   "li1ei2ei3ee".bdecode   #=> [1, 2, 3]
-  #
-  def bdecode
-    BEncode.load(self)
   end
 end

--- a/lib/bencode/parser.rb
+++ b/lib/bencode/parser.rb
@@ -5,13 +5,14 @@ module BEncode
     attr_reader :stream
 
     def initialize(stream)
-      if stream.kind_of?(IO) || stream.kind_of?(StringIO)
-        @stream = stream
-      elsif stream.respond_to? :string
-        @stream = StringIO.new stream.string
-      elsif stream.respond_to? :to_s
-        @stream = StringIO.new stream.to_s
-      end
+      @stream =
+        if stream.kind_of?(IO) || stream.kind_of?(StringIO)
+          stream
+        elsif stream.respond_to? :string
+          StringIO.new stream.string
+        elsif stream.respond_to? :to_s
+          StringIO.new stream.to_s
+        end
     end
 
     def parse!


### PR DESCRIPTION
I found a String extension snuck into `decode.rb` so I moved it to the right place.
