### PR TITLE
UTF-8 encoding bugfix

### DIFF
--- a/lib/bencode/core_ext/string.rb
+++ b/lib/bencode/core_ext/string.rb
@@ -9,7 +9,7 @@ class String
   #   "".bencode      #=> "0:"
   #
   def bencode
-    "#{length}:#{self}"
+    "#{bytesize}:#{self}"
   end
 
   #

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -1,8 +1,10 @@
+# encoding: utf-8
 require 'environment'
 
 class EncodingTest < MiniTest::Unit::TestCase
   context "The BEncode encoder" do
     should_encode "i42e", 42
     should_encode "3:foo", "foo"
+    should_encode "5:café", "café"
   end
 end


### PR DESCRIPTION
Here is a fix about UTF8 encoding (wrong size inserted in chars instead of bytes).
~~I also cleaned a bit the structure and updated the gemspec to new convetions.~~
