### PR TITLE
core_ext/io.rb: use File::open instead of IO::open

### DIFF
--- a/lib/bencode/core_ext/io.rb
+++ b/lib/bencode/core_ext/io.rb
@@ -1,10 +1,10 @@
-class IO  
+class IO
   def self.bdecode(filename)
-    open(filename, 'rb') {|io| io.bdecode}
+    File::open(filename, 'rb') {|io| io.bdecode}
   end
 
   def self.bencode(filename)
-    open(filename, 'rb') {|io| io.bencode}
+    File::open(filename, 'rb') {|io| io.bencode}
   end
 
   def bdecode


### PR DESCRIPTION
(IO::open) accepts an Integer (a #fd) as its first argument.
If we have a file name, we need to use (File::open) instead.
